### PR TITLE
Export to allow access to outside clients

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,4 +100,6 @@ module.exports = function (policyName) {
 
 module.exports.PasswordPolicy = PasswordPolicy;
 
+module.exports.charsets = charsets;
+
 // module.exports.rulesToApply = rulesToApply;


### PR DESCRIPTION
I was getting errors that 'charsets' was undefined. when trying to set a rule like so:

```javascript
var PasswordPolicy = require('password-sheriff').PasswordPolicy;

var enforcer = {};

enforcer.uppers = new PasswordPolicy({contains: {
	expressions: [charsets.upperCase]
}});
```

Going in and exporting this allowed access to it and worked fine:

```javascript
var PasswordPolicy = require('password-sheriff').PasswordPolicy;
var charsets = require('password-sheriff').charsets;

var enforcer = {};

enforcer.uppers = new PasswordPolicy({contains: {
	expressions: [charsets.upperCase]
}});
```