### PR TITLE
Removing explain parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Password Rules are objects that implement the following methods:
 
  * `rule.validate(options)`: method called after the rule was created in order to validate `options` arguments.
  * `rule.assert(options, password)`: returns true if `password` is valid.
- * `rule.explain(options)`: returns an object with `code`, `message` and `format` attributes:
+ * `rule.explain()`: returns an object with `code`, `message` and `format` attributes:
    * `code`: Identifier of the rule. This attribute is meant to aid i18n.
    * `message`: Description of the rule that must be formatted using `util.format`.
    * `format`: Array of `string` or `Number` that will be used for the replacements required in `message`.


### PR DESCRIPTION
The `explain` method no longer accepts any parameters. Not sure what to do with the `Example of rule.explain method` text below the list though?