### PR TITLE
Fix link for auth0.com website

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
Previously the link was broken and refer to `https://github.com/auth0/password-sheriff/blob/master/auth0.com`.