### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## [v1.1.1](https://github.com/auth0/password-sheriff/tree/v1.1.1) (2021-09-02)
+
+**Changed**
+
+- Inline `util.format` function [\#27](https://github.com/auth0/password-sheriff/pull/27) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+**Fixed**
+
+- Grammar on 'containsAtLeast' messaging [\#28](https://github.com/auth0/password-sheriff/pull/27) ([stevehobbsdev](https://github.com/stevehobbsdev))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "password-sheriff",
   "description": "Password policy checker/enforcer.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
**Changed**

- Inline `util.format` function [\#27](https://github.com/auth0/password-sheriff/pull/27) ([stevehobbsdev](https://github.com/stevehobbsdev))

**Fixed**

- Grammar on 'containsAtLeast' messaging [\#28](https://github.com/auth0/password-sheriff/pull/27) ([stevehobbsdev](https://github.com/stevehobbsdev))
